### PR TITLE
Add interfaces for Connection and Server

### DIFF
--- a/handlers/command.go
+++ b/handlers/command.go
@@ -92,7 +92,7 @@ func (c *connection) handleMessage() (log *zap.Logger, err error) {
 func (c *connection) roundTrip(wm []byte) (res []byte, log *zap.Logger, err error) {
 	log = c.log
 
-	var conn *pool.Connection
+	var conn pool.ConnectionWrapper
 	if conn, err = c.checkoutConnection(); err != nil {
 		return
 	}
@@ -111,7 +111,7 @@ func (c *connection) roundTrip(wm []byte) (res []byte, log *zap.Logger, err erro
 	return
 }
 
-func (c *connection) checkoutConnection() (conn *pool.Connection, err error) {
+func (c *connection) checkoutConnection() (conn pool.ConnectionWrapper, err error) {
 	defer func(start time.Time) {
 		addr := ""
 		if conn != nil {

--- a/pool/connection.go
+++ b/pool/connection.go
@@ -143,6 +143,17 @@ func (c *connection) closed() bool {
 	return atomic.LoadInt32(&c.connected) == disconnected
 }
 
+// ConnectionWrapper implementations wrap a net.Conn object
+type ConnectionWrapper interface {
+	Conn() net.Conn
+	Close() error
+	Return() error
+	Alive() bool
+	ID() uint64
+	Address() Address
+	LocalAddress() Address
+}
+
 // Connection implements the driver.Connection interface to allow reading and writing wire
 // messages and the driver.Expirable interface to allow expiring.
 type Connection struct {

--- a/pool/server.go
+++ b/pool/server.go
@@ -34,6 +34,13 @@ const (
 	initialized
 )
 
+// ServerWrapper implementations wrap a connection to a server in the pool
+type ServerWrapper interface {
+	Connect() error
+	Disconnect(ctx context.Context) error
+	Connection(ctx context.Context) (ConnectionWrapper, error)
+}
+
 // Server is a single server within a topology.
 type Server struct {
 	cfg             *serverConfig
@@ -119,7 +126,7 @@ func (s *Server) Disconnect(ctx context.Context) error {
 }
 
 // Connection gets a connection to the server.
-func (s *Server) Connection(ctx context.Context) (*Connection, error) {
+func (s *Server) Connection(ctx context.Context) (ConnectionWrapper, error) {
 	if s.pool.monitor != nil {
 		s.pool.monitor.Event(&Event{
 			Type:    "ConnectionCheckOutStarted",


### PR DESCRIPTION
This adds interfaces to abstract the methods for the Connection and Server structs.

The motivation here is to unblock unit testing with mock Connection and Server objects.

I opted to add new `ConnectionWrapper` and `ServerWrapper` interfaces instead of changing `Server` and `Connection` to interfaces. This limits the breaking changes that would affect Redisbetween.

There's still 1 breaking change I couldn't get around: `Server.Connection` now returns `ConnectionWrapper` instead of `*Connection`. I'll make the change in RedisBetween to fix that if this gets merged.