### PR TITLE
[IM-8664] Adding Connection inactivity logic to pool connections

### DIFF
--- a/pool/connection.go
+++ b/pool/connection.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 var globalConnectionID uint64 = 1
@@ -28,6 +29,7 @@ type connection struct {
 	cancelConnectContext context.CancelFunc
 	connectContextMade   chan struct{}
 	connectContextMutex  sync.Mutex
+	lastUsedTime         time.Time // the last time this connection was established
 
 	// pool related fields
 	pool         *pool
@@ -49,6 +51,7 @@ func newConnection(addr Address, opts ...ConnectionOption) (*connection, error) 
 		connectDone:        make(chan struct{}),
 		config:             cfg,
 		connectContextMade: make(chan struct{}),
+		lastUsedTime:       time.Now(),
 	}
 	atomic.StoreInt32(&c.connected, initialized)
 

--- a/pool/connection.go
+++ b/pool/connection.go
@@ -29,7 +29,7 @@ type connection struct {
 	cancelConnectContext context.CancelFunc
 	connectContextMade   chan struct{}
 	connectContextMutex  sync.Mutex
-	lastUsedTime         time.Time // the last time this connection was established
+	expiresAfter         time.Time // the time until when this connection can stay idle
 
 	// pool related fields
 	pool         *pool
@@ -51,7 +51,6 @@ func newConnection(addr Address, opts ...ConnectionOption) (*connection, error) 
 		connectDone:        make(chan struct{}),
 		config:             cfg,
 		connectContextMade: make(chan struct{}),
-		lastUsedTime:       time.Now(),
 	}
 	atomic.StoreInt32(&c.connected, initialized)
 

--- a/pool/monitoring.go
+++ b/pool/monitoring.go
@@ -52,7 +52,7 @@ const (
 	ReasonStale             = "stale"
 	ReasonConnectionErrored = "connectionError"
 	ReasonTimedOut          = "timeout"
-	ReasonConnectionExpired               = "old"
+	ReasonConnectionExpired = "old"
 )
 
 // strings for pool command monitoring types

--- a/pool/monitoring.go
+++ b/pool/monitoring.go
@@ -52,6 +52,7 @@ const (
 	ReasonStale             = "stale"
 	ReasonConnectionErrored = "connectionError"
 	ReasonTimedOut          = "timeout"
+	ReasonOld               = "old"
 )
 
 // strings for pool command monitoring types

--- a/pool/monitoring.go
+++ b/pool/monitoring.go
@@ -52,7 +52,7 @@ const (
 	ReasonStale             = "stale"
 	ReasonConnectionErrored = "connectionError"
 	ReasonTimedOut          = "timeout"
-	ReasonOld               = "old"
+	ReasonConnectionExpired               = "old"
 )
 
 // strings for pool command monitoring types

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -39,12 +39,12 @@ func (pe Error) Error() string { return string(pe) }
 
 // poolConfig contains all aspects of the pool that can be configured
 type poolConfig struct {
-	Address              Address
-	MinPoolSize          uint64
-	MaxPoolSize          uint64 // MaxPoolSize is not used because handling the max number of connections in the pool is handled in server. This is only used for command monitoring
-	PoolMonitor          *Monitor
+	Address            Address
+	MinPoolSize        uint64
+	MaxPoolSize        uint64 // MaxPoolSize is not used because handling the max number of connections in the pool is handled in server. This is only used for command monitoring
+	PoolMonitor        *Monitor
 	ConnectionLifeSpan time.Duration // if set, determines how long to keep a connection if left unused
-	MaintainInterval     time.Duration // for ResourcePool periodic element checks
+	MaintainInterval   time.Duration // for ResourcePool periodic element checks
 }
 
 // pool is a wrapper of resource pool that follows the CMAP spec for connection pools
@@ -55,10 +55,10 @@ type pool struct {
 	generation uint64        // must be accessed using atomic package
 	monitor    *Monitor
 
-	connected  int32 // Must be accessed using the sync/atomic package.
-	nextid     uint64
-	opened     map[uint64]*connection // opened holds all of the currently open connections.
-	sem        *semaphore.Weighted
+	connected          int32 // Must be accessed using the sync/atomic package.
+	nextid             uint64
+	opened             map[uint64]*connection // opened holds all of the currently open connections.
+	sem                *semaphore.Weighted
 	connectionLifeSpan time.Duration // max allowed connection idleness
 	sync.Mutex
 }
@@ -135,18 +135,18 @@ func newPool(config poolConfig, connOpts ...ConnectionOption) (*pool, error) {
 	}
 
 	pool := &pool{
-		address:    config.Address,
-		monitor:    config.PoolMonitor,
-		connected:  disconnected,
-		opened:     make(map[uint64]*connection),
-		opts:       opts,
-		sem:        semaphore.NewWeighted(int64(maxConns)),
+		address:   config.Address,
+		monitor:   config.PoolMonitor,
+		connected: disconnected,
+		opened:    make(map[uint64]*connection),
+		opts:      opts,
+		sem:       semaphore.NewWeighted(int64(maxConns)),
 	}
 	if config.ConnectionLifeSpan == 0 {
-    pool.connectionLifeSpan = math.MaxInt64 * time.Nanosecond
-  } else {
-    pool.connectionLifeSpan = config.ConnectionLifeSpan
-  }
+		pool.connectionLifeSpan = math.MaxInt64 * time.Nanosecond
+	} else {
+		pool.connectionLifeSpan = config.ConnectionLifeSpan
+	}
 	maintainInterval := config.MaintainInterval
 	if maintainInterval == 0 {
 		maintainInterval = defaultMaintainInterval
@@ -278,7 +278,7 @@ func (p *pool) makeNewConnection() (*connection, string, error) {
 	c.pool = p
 	c.poolID = atomic.AddUint64(&p.nextid, 1)
 	c.generation = atomic.LoadUint64(&p.generation)
-  c.expiresAfter = time.Now().Add(p.connectionLifeSpan)
+	c.expiresAfter = time.Now().Add(p.connectionLifeSpan)
 
 	if p.monitor != nil {
 		p.monitor.Event(&Event{

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -8,7 +8,6 @@ package pool
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -148,7 +147,6 @@ func newPool(config poolConfig, connOpts ...ConnectionOption) (*pool, error) {
 	if maintainInterval == 0 {
 		maintainInterval = defaultMaintainInterval
 	}
-	fmt.Println("maintainInterval:", maintainInterval)
 
 	// we do not pass in config.MaxPoolSize because we manage the max size at this level rather than the resource pool level
 	rpc := resourcePoolConfig{

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"math"
 	"net"
 	"testing"
 	"time"
@@ -29,36 +30,37 @@ func startTcpServer(addr string) {
 
 func TestPoolExpiredFn(t *testing.T) {
 	p := &pool{
-    address:    "localhost:8000",
-		monitor:    nil,
-		connected:  disconnected,
-    opened:     nil,
-		opts:       nil,
-		sem:        nil,
+		address:   "localhost:8000",
+		monitor:   nil,
+		connected: disconnected,
+		opened:    nil,
+		opts:      nil,
+		sem:       nil,
 	}
-  conn, err := newConnection("localhost:0000")
-  assert.NoError(t, err)
-  conn.pool = p
-  assert.Empty(t, conn.expireReason)
-  // first the disconnected case
-  conn.connected = disconnected
-  assert.True(t, connectionExpiredFunc(conn))
-  assert.Equal(t, ReasonPoolClosed, conn.expireReason)
+	conn, err := newConnection("localhost:0000")
+	assert.NoError(t, err)
+	conn.pool = p
+	assert.Empty(t, conn.expireReason)
+	// first the disconnected case
+	conn.connected = disconnected
+	assert.True(t, connectionExpiredFunc(conn))
+	assert.Equal(t, ReasonPoolClosed, conn.expireReason)
 
-  // the connection staleness
-  p.generation++
-  p.connected = connected
-  conn.connected = connected
-  assert.True(t, connectionExpiredFunc(conn))
-  assert.Equal(t, ReasonStale, conn.expireReason)
+	// the connection staleness
+	p.generation++
+	p.connected = connected
+	conn.connected = connected
+	assert.True(t, connectionExpiredFunc(conn))
+	assert.Equal(t, ReasonStale, conn.expireReason)
 
-  // the connection staleness
-  conn.generation = p.generation
-  conn.expiresAfter = time.Now()
-  time.Sleep(100 * time.Millisecond)
-  assert.True(t, connectionExpiredFunc(conn))
-  assert.Equal(t, ReasonConnectionExpired, conn.expireReason)
+	// the connection staleness
+	conn.generation = p.generation
+	conn.expiresAfter = time.Now()
+	time.Sleep(100 * time.Millisecond)
+	assert.True(t, connectionExpiredFunc(conn))
+	assert.Equal(t, ReasonConnectionExpired, conn.expireReason)
 }
+
 // Tests the connectionExpiredFunc and the whole connection expiry
 func TestConnectionExpiry(t *testing.T) {
 	duration := 5 * time.Second
@@ -66,12 +68,12 @@ func TestConnectionExpiry(t *testing.T) {
 	var address Address = "localhost:38888"
 	go startTcpServer(string(address))
 	config := poolConfig{
-		Address:              address,
-		MinPoolSize:          1,
-		MaxPoolSize:          1,
-		PoolMonitor:          nil,
+		Address:            address,
+		MinPoolSize:        1,
+		MaxPoolSize:        1,
+		PoolMonitor:        nil,
 		ConnectionLifeSpan: duration,
-		MaintainInterval:     1 * time.Second,
+		MaintainInterval:   1 * time.Second,
 	}
 
 	p, e := newPool(config)
@@ -98,12 +100,12 @@ func TestGoodConnectionDespiteInactivity(t *testing.T) {
 	var address Address = "localhost:38889"
 	go startTcpServer(string(address))
 	config := poolConfig{
-		Address:              address,
-		MinPoolSize:          1,
-		MaxPoolSize:          1,
-		PoolMonitor:          nil,
+		Address:            address,
+		MinPoolSize:        1,
+		MaxPoolSize:        1,
+		PoolMonitor:        nil,
 		ConnectionLifeSpan: duration,
-		MaintainInterval:     1 * time.Second,
+		MaintainInterval:   1 * time.Second,
 	}
 
 	p, e := newPool(config)
@@ -125,4 +127,46 @@ func TestGoodConnectionDespiteInactivity(t *testing.T) {
 		assert.Equal(t, "", conn.expireReason)
 		assert.Equal(t, connected, conn.connected)
 	}
+}
+
+// make sure connections never expire if lifespan is not set
+func TestNoExpiryWhenNoLifeSpan(t *testing.T) {
+	var address Address = "localhost:38899"
+	go startTcpServer(string(address))
+	config := poolConfig{
+		Address:          address,
+		MinPoolSize:      1,
+		MaxPoolSize:      1,
+		PoolMonitor:      nil,
+		MaintainInterval: 1 * time.Second,
+	}
+
+	never := time.Now().Add(math.MaxInt64 * time.Nanosecond)
+	p, e := newPool(config)
+	assert.NoError(t, e)
+	e = p.connect()
+	assert.NoError(t, e)
+	assert.Equal(t, math.MaxInt64*time.Nanosecond, p.connectionLifeSpan)
+
+	// get a reference to a connection
+	ctx := context.TODO()
+	defer ctx.Done()
+	conn, err := p.get(ctx)
+	p.put(conn)
+	assert.NoError(t, err)
+	assert.False(t, connectionExpiredFunc(conn))
+	assert.True(t, conn.expiresAfter.After(never))
+}
+
+// make sure MaintainInterval is set to default when it's not passed in config
+func TestDefaultMaintainInterval(t *testing.T) {
+	config := poolConfig{
+		Address:     "localhost:88888",
+		MinPoolSize: 1,
+		MaxPoolSize: 1,
+		PoolMonitor: nil,
+	}
+	p, e := newPool(config)
+	assert.NoError(t, e)
+	assert.Equal(t, time.Minute, p.conns.maintainInterval)
 }

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -83,14 +83,14 @@ func TestGoodConnectionDespiteInactivity(t *testing.T) {
 	ctx := context.TODO()
 	defer ctx.Done()
 	conn, err := p.get(ctx)
+	p.put(conn)
 	assert.NoError(t, err)
+	assert.False(t, connectionExpiredFunc(conn))
 	if err == nil {
 		time.Sleep(duration)
-		assert.True(t, connectionExpiredFunc(conn))
-		assert.Equal(t, ReasonOld, conn.expireReason)
 		conn, err = p.get(ctx)
 		assert.NoError(t, err)
 		assert.Equal(t, "", conn.expireReason)
-		assert.Equal(t, 1, conn.connected)
+		assert.Equal(t, connected, conn.connected)
 	}
 }

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -1,0 +1,96 @@
+package pool
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net"
+	"testing"
+	"time"
+)
+
+func startTcpServer(addr string) {
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		panic(err)
+	}
+	defer l.Close()
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			panic(err)
+		}
+		go func(conn net.Conn) {
+			fmt.Println("request arrived")
+			conn.Close()
+		}(conn)
+	}
+}
+
+// Tests the connectionExpiredFunc and the whole inactivity aging
+func TestInactivity(t *testing.T) {
+	duration := 5 * time.Second
+
+	var address Address = "localhost:38888"
+	go startTcpServer(string(address))
+	config := poolConfig{
+		Address:              address,
+		MinPoolSize:          1,
+		MaxPoolSize:          1,
+		PoolMonitor:          nil,
+		ConnectionInactivity: duration,
+		MaintainInterval:     1 * time.Second,
+	}
+
+	p, e := newPool(config)
+	assert.NoError(t, e)
+	e = p.connect()
+	assert.NoError(t, e)
+
+	// get a reference to a connection
+	ctx := context.TODO()
+	defer ctx.Done()
+	conn, err := p.get(ctx)
+	assert.NoError(t, err)
+	if err == nil {
+		time.Sleep(duration)
+		assert.True(t, connectionExpiredFunc(conn))
+		assert.Equal(t, ReasonOld, conn.expireReason)
+	}
+}
+
+// Ensures we always get a good connection even if there's inactivity there
+func TestGoodConnectionDespiteInactivity(t *testing.T) {
+	duration := 5 * time.Second
+
+	var address Address = "localhost:38889"
+	go startTcpServer(string(address))
+	config := poolConfig{
+		Address:              address,
+		MinPoolSize:          1,
+		MaxPoolSize:          1,
+		PoolMonitor:          nil,
+		ConnectionInactivity: duration,
+		MaintainInterval:     1 * time.Second,
+	}
+
+	p, e := newPool(config)
+	assert.NoError(t, e)
+	e = p.connect()
+	assert.NoError(t, e)
+
+	// get a reference to a connection
+	ctx := context.TODO()
+	defer ctx.Done()
+	conn, err := p.get(ctx)
+	assert.NoError(t, err)
+	if err == nil {
+		time.Sleep(duration)
+		assert.True(t, connectionExpiredFunc(conn))
+		assert.Equal(t, ReasonOld, conn.expireReason)
+		conn, err = p.get(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, "", conn.expireReason)
+		assert.Equal(t, 1, conn.connected)
+	}
+}

--- a/pool/resource_pool.go
+++ b/pool/resource_pool.go
@@ -96,6 +96,7 @@ func (rp *resourcePool) initialize() {
 }
 
 // add will add a new rpe to the pool, requires that the resource pool is locked
+// The element will be added to the end and will be retrieved from the front
 func (rp *resourcePool) add(e *resourcePoolElement) {
 	if e == nil {
 		e = &resourcePoolElement{
@@ -103,13 +104,16 @@ func (rp *resourcePool) add(e *resourcePoolElement) {
 		}
 	}
 
-	e.next = rp.start
-	if rp.start != nil {
-		rp.start.prev = e
-	}
-	rp.start = e
 	if rp.end == nil {
 		rp.end = e
+	} else {
+		rp.end.next = e
+		e.prev = rp.end
+		rp.end = e
+	}
+
+	if rp.start == nil {
+		rp.start = e
 	}
 	atomic.AddUint64(&rp.size, 1)
 }

--- a/pool/resource_pool_test.go
+++ b/pool/resource_pool_test.go
@@ -1,0 +1,90 @@
+package pool
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var counter = 0
+var config = resourcePoolConfig{
+	MaxSize:          5,
+	MinSize:          0,
+	MaintainInterval: 300 * time.Second,
+	ExpiredFn:        rpExpiredFunc,
+	CloseFn:          rpCloseFunc,
+	InitFn:           rpInitFunc,
+}
+
+func newRp() (*resourcePool, error) {
+	rp, e := newResourcePool(config)
+	return rp, e
+}
+
+func rpInitFunc() interface{} {
+	counter++
+	return counter
+}
+func rpExpiredFunc(interface{}) bool {
+	return false
+}
+func rpCloseFunc(interface{}) {
+
+}
+
+func TestList(t *testing.T) {
+	rp, e := newRp()
+	assert.NoError(t, e)
+	assert.Equal(t, uint64(0), rp.totalSize)
+	newItem := 1
+	assert.True(t, rp.Put(newItem))
+	assert.Equal(t, uint64(1), rp.size)
+	assert.NotNil(t, rp.start)
+	assert.NotNil(t, rp.end)
+	assert.Nil(t, rp.start.prev)
+	assert.Nil(t, rp.start.next)
+	assert.Nil(t, rp.end.next)
+	assert.Nil(t, rp.end.prev)
+
+	entry := rp.Get()
+	assert.NotNil(t, entry)
+	assert.Equal(t, uint64(0), rp.size)
+	assert.Equal(t, newItem, entry)
+	assert.Nil(t, rp.start)
+	assert.Nil(t, rp.end)
+
+	assert.True(t, rp.Put(newItem))
+	assert.Equal(t, uint64(1), rp.size)
+	assert.Equal(t, newItem, entry)
+	assert.NotNil(t, rp.start)
+	assert.NotNil(t, rp.end)
+	assert.Nil(t, rp.start.prev)
+	assert.Nil(t, rp.start.next)
+}
+
+func TestAddedToEnd(t *testing.T) {
+	rp, e := newRp()
+	assert.NoError(t, e)
+	newItem := 1
+	assert.True(t, rp.Put(newItem))
+	newItem = 2
+	assert.True(t, rp.Put(newItem))
+	// Start should be 1; end should be 2
+	assert.Equal(t, 1, rp.start.value.(int))
+	assert.Equal(t, 2, rp.end.value.(int))
+}
+
+func TestTakenFromStart(t *testing.T) {
+	rp, e := newRp()
+	assert.NoError(t, e)
+	newItem := 1
+	assert.True(t, rp.Put(newItem))
+	newItem = 2
+	assert.True(t, rp.Put(newItem))
+	// We'll get two elements; in order should 1 and 2
+	item1 := rp.Get().(int)
+	item2 := rp.Get().(int)
+	assert.Equal(t, 1, item1)
+	assert.Equal(t, 2, item2)
+}


### PR DESCRIPTION
This is a change that is needed by Redisbetween.
It can benefit the existing `healthcheck`s by allowing the checks to be distributed amongst all existing connections for a pool. Previously, the connection pool behaved like a stack. It now behaves a like a queue. Connections are taken from the front and added to the back. This gives connections equal chance for being used.

Another aspect of this change is the addition of an `expiresAfter` field for each connection. This itself can be used in Redisbetween to ensure stale connections are removed in a timely manner in response to the Redis nodes closing them based on their `timeout` values in their configuration parameter groups. The connection pool already has a cyclic function that checks the state of each connection. It now performs one more check and that is to see if the connection is `expired` or not. If the cyclic check fails, the connection object is discarded and a new one is created (existing behavior)