### PR TITLE
[trivial] Opening the path for poolConfig changes to be brought in

### DIFF
--- a/elasticache/elasticache.go
+++ b/elasticache/elasticache.go
@@ -12,7 +12,8 @@ import (
 )
 
 // ClusterNodes Reads from the elasticache config node (endpoint) and
-//              returns a slice of memcache node addresses
+//
+//	returns a slice of memcache node addresses
 func ClusterNodes(l *zap.Logger, endpoint string) ([]string, error) {
 	if !strings.Contains(endpoint, ":") {
 		endpoint = endpoint + ":11211"

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -68,12 +68,12 @@ func TestConnectionExpiry(t *testing.T) {
 	var address Address = "localhost:38888"
 	go startTcpServer(string(address))
 	config := poolConfig{
-		Address:            address,
-		MinPoolSize:        1,
-		MaxPoolSize:        1,
-		PoolMonitor:        nil,
-		ConnectionLifeSpan: duration,
-		MaintainInterval:   1 * time.Second,
+		Address:          address,
+		MinPoolSize:      1,
+		MaxPoolSize:      1,
+		PoolMonitor:      nil,
+		IdleTimeout:      duration,
+		MaintainInterval: 1 * time.Second,
 	}
 
 	p, e := newPool(config)
@@ -100,12 +100,12 @@ func TestGoodConnectionDespiteInactivity(t *testing.T) {
 	var address Address = "localhost:38889"
 	go startTcpServer(string(address))
 	config := poolConfig{
-		Address:            address,
-		MinPoolSize:        1,
-		MaxPoolSize:        1,
-		PoolMonitor:        nil,
-		ConnectionLifeSpan: duration,
-		MaintainInterval:   1 * time.Second,
+		Address:          address,
+		MinPoolSize:      1,
+		MaxPoolSize:      1,
+		PoolMonitor:      nil,
+		IdleTimeout:      duration,
+		MaintainInterval: 1 * time.Second,
 	}
 
 	p, e := newPool(config)
@@ -129,8 +129,8 @@ func TestGoodConnectionDespiteInactivity(t *testing.T) {
 	}
 }
 
-// make sure connections never expire if lifespan is not set
-func TestNoExpiryWhenNoLifeSpan(t *testing.T) {
+// make sure connections never expire if IdleTimeout is not set
+func TestNoExpiryWhenNoIdleTimeout(t *testing.T) {
 	var address Address = "localhost:38899"
 	go startTcpServer(string(address))
 	config := poolConfig{
@@ -146,7 +146,7 @@ func TestNoExpiryWhenNoLifeSpan(t *testing.T) {
 	assert.NoError(t, e)
 	e = p.connect()
 	assert.NoError(t, e)
-	assert.Equal(t, math.MaxInt64*time.Nanosecond, p.connectionLifeSpan)
+	assert.Equal(t, math.MaxInt64*time.Nanosecond, p.idleTimeout)
 
 	// get a reference to a connection
 	ctx := context.TODO()

--- a/pool/server.go
+++ b/pool/server.go
@@ -83,10 +83,12 @@ func NewServer(addr Address, opts ...ServerOption) (*Server, error) {
 		MinPoolSize: cfg.minConns,
 		MaxPoolSize: cfg.maxConns,
 		PoolMonitor: cfg.poolMonitor,
-		IdleTimeout: cfg.idleTimeout,
 	}
-	if cfg.idleTimeout > 0 && cfg.idleTimeout < defaultMaintainInterval {
-		pc.MaintainInterval = cfg.idleTimeout
+	if cfg.idleTimeout > 0 {
+		pc.IdleTimeout = cfg.idleTimeout
+		if cfg.idleTimeout < defaultMaintainInterval {
+			pc.MaintainInterval = cfg.idleTimeout
+		}
 	}
 
 	s.pool, err = newPool(pc, cfg.connectionOpts...)

--- a/pool/server.go
+++ b/pool/server.go
@@ -83,6 +83,10 @@ func NewServer(addr Address, opts ...ServerOption) (*Server, error) {
 		MinPoolSize: cfg.minConns,
 		MaxPoolSize: cfg.maxConns,
 		PoolMonitor: cfg.poolMonitor,
+		IdleTimeout: cfg.idleTimeout,
+	}
+	if cfg.idleTimeout > 0 && cfg.idleTimeout < defaultMaintainInterval {
+		pc.MaintainInterval = cfg.idleTimeout
 	}
 
 	s.pool, err = newPool(pc, cfg.connectionOpts...)

--- a/pool/server_options.go
+++ b/pool/server_options.go
@@ -6,11 +6,16 @@
 
 package pool
 
+import (
+	"time"
+)
+
 type serverConfig struct {
 	connectionOpts []ConnectionOption
 	maxConns       uint64
 	minConns       uint64
 	poolMonitor    *Monitor
+	idleTimeout    time.Duration
 }
 
 func newServerConfig(opts ...ServerOption) (*serverConfig, error) {
@@ -62,6 +67,14 @@ func WithMinConnections(fn func(uint64) uint64) ServerOption {
 func WithConnectionPoolMonitor(fn func(*Monitor) *Monitor) ServerOption {
 	return func(cfg *serverConfig) error {
 		cfg.poolMonitor = fn(cfg.poolMonitor)
+		return nil
+	}
+}
+
+// WithConnectionPoolMonitor configures the monitor for all connection pool actions
+func WithIdleTimeout(fn func(time.Duration) time.Duration) ServerOption {
+	return func(cfg *serverConfig) error {
+		cfg.idleTimeout = fn(cfg.idleTimeout)
 		return nil
 	}
 }


### PR DESCRIPTION
Redisbetween uses `Server` and `ServerOptions` and does not create the `pool` directly. So these structs needed to be modified to carry the additional `idleTimeout` property

Some name changes were also applied for consistency between this project and redisbetween